### PR TITLE
[Backend] 列追加対応

### DIFF
--- a/002-develop/web-developer-training-backend/api/app/application/genre/GenreDto.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/genre/GenreDto.scala
@@ -1,4 +1,3 @@
 package application.genre
 
-case class GenreDto(id: Long, genreName: String)
-
+case class GenreDto(id: Long, genreCode: String, genreName: String)

--- a/002-develop/web-developer-training-backend/api/app/application/genre/GenreServiceImpl.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/genre/GenreServiceImpl.scala
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class GenreServiceImpl @Inject() (val genreRepository: GenreRepository) extends GenreService {
   override def getGenres: List[GenreDto] = {
     DB localTx { implicit session =>
-      genreRepository.findAll().map(genre => GenreDto(genre.id, genre.genreName))
+      genreRepository.findAll().map(genre => GenreDto(genre.id, genre.genreCode, genre.genreName))
     }
   }
 }

--- a/002-develop/web-developer-training-backend/api/app/controller/genre/GenreController.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/genre/GenreController.scala
@@ -12,7 +12,7 @@ class GenreController @Inject() (val cc: ControllerComponents, val genreService:
     Ok(
       Json.toJson(
         genreService.getGenres
-          .map(genre => GenreResponse(genre.id.toInt, genre.genreName))
+          .map(genre => GenreResponse(genre.id.toInt, genre.genreCode, genre.genreName))
       )
     )
   }

--- a/002-develop/web-developer-training-backend/api/app/controller/genre/GenreResponse.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/genre/GenreResponse.scala
@@ -2,7 +2,7 @@ package controller.genre
 
 import play.api.libs.json.{ Json, Writes }
 
-case class GenreResponse(id: Int, genreName: String)
+case class GenreResponse(id: Int, genreCode: String, genreName: String)
 
 object GenreResponse {
   implicit val writes: Writes[GenreResponse] = Json.writes[GenreResponse]

--- a/002-develop/web-developer-training-backend/api/app/domain/genre/Genre.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/genre/Genre.scala
@@ -2,7 +2,7 @@ package domain.genre
 
 import infrastructure.genre.GenreEntity
 
-case class Genre private (id: Long, genreName: String) {
+case class Genre private (id: Long, genreCode: String, genreName: String) {
   if (id < 0) {
     throw new CreateGenreException("Genre idは自然数である必要があります")
   }
@@ -13,6 +13,6 @@ case class Genre private (id: Long, genreName: String) {
 
 object Genre {
   def build(genreEntity: GenreEntity): Genre = {
-    new Genre(genreEntity.id, genreEntity.genreName)
+    new Genre(genreEntity.id, genreEntity.genreCode, genreEntity.genreName)
   }
 }

--- a/002-develop/web-developer-training-backend/api/app/infrastructure/genre/GenreEntity.scala
+++ b/002-develop/web-developer-training-backend/api/app/infrastructure/genre/GenreEntity.scala
@@ -4,15 +4,16 @@ import org.joda.time.DateTime
 import scalikejdbc._
 import scalikejdbc.jodatime.JodaTypeBinder._
 
-case class GenreEntity(id: Long, genreName: String, createdAt: DateTime, updatedAt: DateTime) {}
+case class GenreEntity(id: Long, genreCode: String, genreName: String, createdAt: DateTime, updatedAt: DateTime) {}
 
 object GenreEntity extends SQLSyntaxSupport[GenreEntity] {
   override val tableName: String = "genre"
-  override val columns = Seq("id", "genre_name", "created_at", "updated_at")
+  override val columns = Seq("id", "genre_code", "genre_name", "created_at", "updated_at")
 
   def apply(g: SyntaxProvider[GenreEntity])(rs: WrappedResultSet): GenreEntity = apply(g.resultName)(rs)
   def apply(g: ResultName[GenreEntity])(rs: WrappedResultSet): GenreEntity = new GenreEntity(
     id = rs.get(g.id),
+    genreCode = rs.get(g.genreCode),
     genreName = rs.get(g.genreName),
     createdAt = rs.get(g.createdAt),
     updatedAt = rs.get(g.updatedAt)

--- a/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v03_DDL.sql
+++ b/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v03_DDL.sql
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS genre;
 CREATE TABLE genre
 (
     id           BIGINT NOT NULL AUTO_INCREMENT,
+    genre_code   VARCHAR(10) NOT NULL,
     genre_name   VARCHAR(30) NOT NULL,
     created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at   TIMESTAMP NULL,

--- a/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v03_DDL.sql
+++ b/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v03_DDL.sql
@@ -33,6 +33,7 @@ CREATE TABLE quiz_choice
     quiz_id      BIGINT NOT NULL,
     content      VARCHAR(1000) NOT NULL,
     is_answer    TINYINT(1) NOT NULL,
+    explanation  VARCHAR(1000) NULL,
     created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at   TIMESTAMP NULL,
     PRIMARY KEY (id),

--- a/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v04_DML.sql
+++ b/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v04_DML.sql
@@ -1,7 +1,8 @@
 -- genre
-INSERT INTO genre (id, genre_name) VALUES(1, 'フロントエンド');
-INSERT INTO genre (id, genre_name) VALUES(2, 'バックエンド');
-INSERT INTO genre (id, genre_name) VALUES(3, 'インフラストラクチャー');
+INSERT INTO genre (id, genre_code, genre_name) VALUES(1, 'GENRE_001', 'フロントエンド');
+INSERT INTO genre (id, genre_code, genre_name) VALUES(2, 'GENRE_002', 'バックエンド');
+INSERT INTO genre (id, genre_code, genre_name) VALUES(3, 'GENRE_003', 'インフラ');
+INSERT INTO genre (id, genre_code, genre_name) VALUES(4, 'GENRE_004', 'データベース');
 
 -- quiz
 INSERT INTO quiz (id, genre_id, question) VALUES(1, 1, 'ビルド時にレンダリングをおこない、WebサーバーにHTMLファイルをキャッシュするレンダリングの種類はどれでしょうか？');

--- a/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v04_DML.sql
+++ b/002-develop/web-developer-training-backend/api/docker/db/mysql/sql/v04_DML.sql
@@ -8,20 +8,20 @@ INSERT INTO quiz (id, genre_id, question) VALUES(1, 1, 'ビルド時にレンダ
 INSERT INTO quiz (id, genre_id, question) VALUES(2, 1, 'グローバルstateに保存した値がページをリロードした際に消えてしまうのはどれでしょうか？');
 
 -- quiz_choice
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(1, 1, 'CSR', 0);
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(2, 1, 'SSR', 0);
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(3, 1, 'SG', 1);
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(4, 1, 'ISR', 0);
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(1, 1, 'CSR', 0, null);
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(2, 1, 'SSR', 0, null);
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(3, 1, 'SG', 1, '解説文が入ります解説文が入ります解説文が入ります');
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(4, 1, 'ISR', 0, null);
 
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(5, 2, 'インメモリ', 1);
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(6, 2, 'ローカルストレージ', 0);
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(7, 2, 'セッションストレージ', 0);
-INSERT INTO quiz_choice (id, quiz_id, content, is_answer)
-  VALUES(8, 2, 'Cookie', 0);
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(5, 2, 'インメモリ', 1, '解説文が入ります解説文が入ります解説文が入ります');
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(6, 2, 'ローカルストレージ', 0, null);
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(7, 2, 'セッションストレージ', 0, null);
+INSERT INTO quiz_choice (id, quiz_id, content, is_answer, explanation)
+  VALUES(8, 2, 'Cookie', 0, null);


### PR DESCRIPTION
## 実施事項
- quiz_choiceテーブル
  - 解答に対する解説を管理する目的として、`explanation`列を追加

- genreテーブル
  - フロントエンドでジャンル名に対するアイコンの紐付けができるようにコード値の定義を追加（`genre_code`）

- ジャンル取得API
  - `genre_code`列追加に伴い、レスポンスに該当のプロパティを追加

http://localhost:9000/api/v1/genre
```
[
    {
        "id": 1,
        "genreCode": "GENRE_001",
        "genreName": "フロントエンド"
    },
    {
        "id": 2,
        "genreCode": "GENRE_002",
        "genreName": "バックエンド"
    },
    {
        "id": 3,
        "genreCode": "GENRE_003",
        "genreName": "インフラ"
    },
    {
        "id": 4,
        "genreCode": "GENRE_004",
        "genreName": "データベース"
    }
]
```

## その他
