### PR TITLE
[Backend] ジャンルのクイズ一覧取得API実装

### DIFF
--- a/002-develop/web-developer-training-backend/api/app/application/genre/GenreService.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/genre/GenreService.scala
@@ -1,6 +1,7 @@
 package application.genre
 
 import com.google.inject.ImplementedBy
+
 @ImplementedBy(classOf[GenreServiceImpl])
 trait GenreService {
   def getGenres: List[GenreDto]

--- a/002-develop/web-developer-training-backend/api/app/application/quiz/QuizDto.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/quiz/QuizDto.scala
@@ -1,3 +1,3 @@
 package application.quiz
 
-case class QuizDto(id: Long, genreId: Long, question: String)
+case class QuizDto(id: Long, genreId: Long, question: String, options: List[QuizOptionDto])

--- a/002-develop/web-developer-training-backend/api/app/application/quiz/QuizDto.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/quiz/QuizDto.scala
@@ -1,0 +1,3 @@
+package application.quiz
+
+case class QuizDto(id: Long, genreId: Long, question: String)

--- a/002-develop/web-developer-training-backend/api/app/application/quiz/QuizOptionDto.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/quiz/QuizOptionDto.scala
@@ -1,0 +1,3 @@
+package application.quiz
+
+case class QuizOptionDto(id: Long, option: String)

--- a/002-develop/web-developer-training-backend/api/app/application/quiz/QuizService.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/quiz/QuizService.scala
@@ -1,0 +1,8 @@
+package application.quiz
+
+import com.google.inject.ImplementedBy
+
+@ImplementedBy(classOf[QuizServiceImpl])
+trait QuizService {
+  def getQuizListByGenreId(genreId: Long): List[QuizDto]
+}

--- a/002-develop/web-developer-training-backend/api/app/application/quiz/QuizServiceImpl.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/quiz/QuizServiceImpl.scala
@@ -8,7 +8,17 @@ import javax.inject.Inject
 class QuizServiceImpl @Inject() (val quizRepository: QuizRepository) extends QuizService {
   override def getQuizListByGenreId(genreId: Long): List[QuizDto] = {
     DB localTx { implicit session =>
-      quizRepository.findByGenreId(genreId).map(quiz => QuizDto(quiz.id, quiz.genreId, quiz.question))
+      quizRepository
+        .findByGenreId(genreId)
+        .map(
+          quiz =>
+            QuizDto(
+              quiz.id,
+              quiz.genreId,
+              quiz.question,
+              quiz.options.map(option => QuizOptionDto(option.id, option.content))
+            )
+        )
     }
   }
 }

--- a/002-develop/web-developer-training-backend/api/app/application/quiz/QuizServiceImpl.scala
+++ b/002-develop/web-developer-training-backend/api/app/application/quiz/QuizServiceImpl.scala
@@ -1,0 +1,14 @@
+package application.quiz
+
+import domain.quiz.QuizRepository
+import scalikejdbc._
+
+import javax.inject.Inject
+
+class QuizServiceImpl @Inject() (val quizRepository: QuizRepository) extends QuizService {
+  override def getQuizListByGenreId(genreId: Long): List[QuizDto] = {
+    DB localTx { implicit session =>
+      quizRepository.findByGenreId(genreId).map(quiz => QuizDto(quiz.id, quiz.genreId, quiz.question))
+    }
+  }
+}

--- a/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizController.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizController.scala
@@ -13,7 +13,15 @@ class QuizController @Inject() (val cc: ControllerComponents, val quizService: Q
       Json.toJson(
         quizService
           .getQuizListByGenreId(genreId)
-          .map(quiz => QuizResponse(quiz.id.toInt, quiz.genreId.toInt, quiz.question))
+          .map(
+            quiz =>
+              QuizResponse(
+                quiz.id.toInt,
+                quiz.genreId.toInt,
+                quiz.question,
+                quiz.options.map(option => QuizOptionResponse(option.id.toInt, option.option))
+              )
+          )
       )
     )
   }

--- a/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizController.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizController.scala
@@ -1,0 +1,20 @@
+package controller.quiz
+
+import application.quiz.QuizService
+import com.google.inject.{ Inject, Singleton }
+import play.api.mvc._
+import play.api.libs.json._
+
+@Singleton
+class QuizController @Inject() (val cc: ControllerComponents, val quizService: QuizService)
+    extends AbstractController(cc) {
+  def getQuizListByGenreId(genreId: Long) = Action {
+    Ok(
+      Json.toJson(
+        quizService
+          .getQuizListByGenreId(genreId)
+          .map(quiz => QuizResponse(quiz.id.toInt, quiz.genreId.toInt, quiz.question))
+      )
+    )
+  }
+}

--- a/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizOptionResponse.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizOptionResponse.scala
@@ -1,0 +1,9 @@
+package controller.quiz
+
+case class QuizOptionResponse(id: Int, option: String)
+
+object QuizOptionResponse {
+  import play.api.libs.json.{ Json, Writes }
+
+  implicit val writes: Writes[QuizOptionResponse] = Json.writes[QuizOptionResponse]
+}

--- a/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizResponse.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizResponse.scala
@@ -1,0 +1,9 @@
+package controller.quiz
+
+import play.api.libs.json.{ Json, Writes }
+
+case class QuizResponse(id: Int, genreId: Int, question: String)
+
+object QuizResponse {
+  implicit val writes: Writes[QuizResponse] = Json.writes[QuizResponse]
+}

--- a/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizResponse.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/quiz/QuizResponse.scala
@@ -2,7 +2,7 @@ package controller.quiz
 
 import play.api.libs.json.{ Json, Writes }
 
-case class QuizResponse(id: Int, genreId: Int, question: String)
+case class QuizResponse(id: Int, genreId: Int, question: String, options: List[QuizOptionResponse])
 
 object QuizResponse {
   implicit val writes: Writes[QuizResponse] = Json.writes[QuizResponse]

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/CreateQuizException.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/CreateQuizException.scala
@@ -1,0 +1,3 @@
+package domain.quiz
+
+class CreateQuizException(val message: String) extends RuntimeException(message)

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/Quiz.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/Quiz.scala
@@ -1,0 +1,21 @@
+package domain.quiz
+
+import infrastructure.quiz.QuizEntity
+
+case class Quiz private (id: Long, genreId: Long, question: String) {
+  if (id < 0) {
+    throw new CreateQuizException("Quiz idは自然数である必要があります")
+  }
+  if (genreId < 0) {
+    throw new CreateQuizException("Genre idは自然数である必要があります")
+  }
+  if (question.length > 1000) {
+    throw new CreateQuizException("Questionは1000文字以内である必要があります")
+  }
+}
+
+object Quiz {
+  def build(quizEntity: QuizEntity): Quiz = {
+    new Quiz(quizEntity.id, quizEntity.genreId, quizEntity.question)
+  }
+}

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/Quiz.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/Quiz.scala
@@ -1,8 +1,8 @@
 package domain.quiz
 
-import infrastructure.quiz.QuizEntity
+import infrastructure.quiz.{ QuizChoiceEntity, QuizEntity }
 
-case class Quiz private (id: Long, genreId: Long, question: String) {
+case class Quiz private (id: Long, genreId: Long, question: String, options: List[QuizChoice]) {
   if (id < 0) {
     throw new CreateQuizException("Quiz idは自然数である必要があります")
   }
@@ -15,7 +15,7 @@ case class Quiz private (id: Long, genreId: Long, question: String) {
 }
 
 object Quiz {
-  def build(quizEntity: QuizEntity): Quiz = {
-    new Quiz(quizEntity.id, quizEntity.genreId, quizEntity.question)
+  def build(quizEntity: QuizEntity, quizChoiceEntityList: List[QuizChoiceEntity]): Quiz = {
+    new Quiz(quizEntity.id, quizEntity.genreId, quizEntity.question, quizChoiceEntityList.map(QuizChoice.build))
   }
 }

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/QuizChoice.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/QuizChoice.scala
@@ -1,0 +1,21 @@
+package domain.quiz
+
+import infrastructure.quiz.QuizChoiceEntity
+
+case class QuizChoice private (id: Long, quizId: Long, content: String, isAnswer: Boolean, explanation: String) {
+  if (content.length > 1000) {
+    throw new CreateQuizException("Contentは1000文字以内である必要があります")
+  }
+}
+
+object QuizChoice {
+  def build(quizChoiceEntity: QuizChoiceEntity): QuizChoice = {
+    new QuizChoice(
+      quizChoiceEntity.id,
+      quizChoiceEntity.quizId,
+      quizChoiceEntity.content,
+      quizChoiceEntity.isAnswer,
+      quizChoiceEntity.explanation
+    )
+  }
+}

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/QuizRepository.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/QuizRepository.scala
@@ -1,0 +1,10 @@
+package domain.quiz
+
+import com.google.inject.ImplementedBy
+import infrastructure.quiz.QuizRepositoryImpl
+import scalikejdbc.DBSession
+
+@ImplementedBy(classOf[QuizRepositoryImpl])
+trait QuizRepository {
+  def findByGenreId(genreId: Long)(implicit session: DBSession): List[Quiz]
+}

--- a/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizChoiceEntity.scala
+++ b/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizChoiceEntity.scala
@@ -1,0 +1,31 @@
+package infrastructure.quiz
+
+import org.joda.time.DateTime
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaTypeBinder._
+
+case class QuizChoiceEntity(
+    id: Long,
+    quizId: Long,
+    content: String,
+    isAnswer: Boolean,
+    explanation: String,
+    createdAt: DateTime,
+    updatedAt: DateTime
+) {}
+
+object QuizChoiceEntity extends SQLSyntaxSupport[QuizChoiceEntity] {
+  override val tableName: String = "quiz_choice"
+  override val columns = Seq("id", "quiz_id", "content", "is_answer", "explanation", "created_at", "updated_at")
+
+  def apply(q: SyntaxProvider[QuizChoiceEntity])(rs: WrappedResultSet): QuizChoiceEntity = apply(q.resultName)(rs)
+  def apply(q: ResultName[QuizChoiceEntity])(rs: WrappedResultSet): QuizChoiceEntity = new QuizChoiceEntity(
+    id = rs.get(q.id),
+    quizId = rs.get(q.quizId),
+    content = rs.get(q.content),
+    isAnswer = rs.get(q.isAnswer),
+    explanation = rs.get(q.explanation),
+    createdAt = rs.get(q.createdAt),
+    updatedAt = rs.get(q.updatedAt)
+  )
+}

--- a/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizEntity.scala
+++ b/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizEntity.scala
@@ -1,0 +1,27 @@
+package infrastructure.quiz
+
+import org.joda.time.DateTime
+import scalikejdbc._
+import scalikejdbc.jodatime.JodaTypeBinder._
+
+case class QuizEntity(
+    id: Long,
+    genreId: Long,
+    question: String,
+    createdAt: DateTime,
+    updatedAt: DateTime
+) {}
+
+object QuizEntity extends SQLSyntaxSupport[QuizEntity] {
+  override val tableName: String = "quiz"
+  override val columns = Seq("id", "genre_id", "question", "created_at", "updated_at")
+
+  def apply(q: SyntaxProvider[QuizEntity])(rs: WrappedResultSet): QuizEntity = apply(q.resultName)(rs)
+  def apply(q: ResultName[QuizEntity])(rs: WrappedResultSet): QuizEntity = new QuizEntity(
+    id = rs.get(q.id),
+    genreId = rs.get(q.genreId),
+    question = rs.get(q.question),
+    createdAt = rs.get(q.createdAt),
+    updatedAt = rs.get(q.updatedAt)
+  )
+}

--- a/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizRepositoryImpl.scala
+++ b/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizRepositoryImpl.scala
@@ -1,16 +1,39 @@
 package infrastructure.quiz
 
-import domain.quiz.{ Quiz, QuizRepository }
+import domain.quiz.{ Quiz, QuizChoice, QuizRepository }
 import scalikejdbc._
 
 class QuizRepositoryImpl extends QuizRepository {
   private val q = QuizEntity.syntax("q")
+  private val qc = QuizChoiceEntity.syntax("qc")
 
   override def findByGenreId(genreId: Long)(implicit session: DBSession): List[Quiz] = {
-    withSQL(select.from(QuizEntity as q).where.eq(q.genreId, genreId).orderBy(q.id))
-      .map(QuizEntity(q.resultName))
+    // ここで、QuizEntityとQuizChoiceEntityを結合して、QuizEntityとQuizChoiceEntityのタプルのリストを取得する
+    // result = [  (QuizEntity(1, 1, "Question 1", ...), QuizChoiceEntity(1, 1, "Choice 1", ...)),  (QuizEntity(1, 1, "Question 1", ...), QuizChoiceEntity(2, 1, "Choice 2", ...)),  (QuizEntity(1, 1, "Question 1", ...), QuizChoiceEntity(3, 1, "Choice 3", ...)),  (QuizEntity(2, 1, "Question 2", ...), QuizChoiceEntity(4, 2, "Choice 1", ...)),  (QuizEntity(2, 1, "Question 2", ...), QuizChoiceEntity(5, 2, "Choice 2", ...)),  ...]
+    val result = withSQL {
+      select
+        .from(QuizEntity as q)
+        .join(QuizChoiceEntity as qc)
+        .on(q.id, qc.quizId)
+        .where
+        .eq(q.genreId, genreId)
+    }.map(rs => {
+        val quizEntity = QuizEntity(q.resultName)(rs)
+        val quizChoiceEntity = QuizChoiceEntity(qc.resultName)(rs)
+        (quizEntity, quizChoiceEntity)
+      })
       .list
       .apply()
-      .map(quiz => Quiz.build(quiz))
+
+    val quizzesWithChoices = result
+      .groupBy(_._1)
+      .map {
+        case (quizEntity, quizEntityAndChoiceEntities) =>
+          val quizChoiceEntities = quizEntityAndChoiceEntities.map(_._2)
+          Quiz.build(quizEntity, quizChoiceEntities)
+      }
+      .toList
+
+    quizzesWithChoices
   }
 }

--- a/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizRepositoryImpl.scala
+++ b/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizRepositoryImpl.scala
@@ -1,0 +1,16 @@
+package infrastructure.quiz
+
+import domain.quiz.{ Quiz, QuizRepository }
+import scalikejdbc._
+
+class QuizRepositoryImpl extends QuizRepository {
+  private val q = QuizEntity.syntax("q")
+
+  override def findByGenreId(genreId: Long)(implicit session: DBSession): List[Quiz] = {
+    withSQL(select.from(QuizEntity as q).where.eq(q.genreId, genreId).orderBy(q.id))
+      .map(QuizEntity(q.resultName))
+      .list
+      .apply()
+      .map(quiz => Quiz.build(quiz))
+  }
+}

--- a/002-develop/web-developer-training-backend/api/conf/routes
+++ b/002-develop/web-developer-training-backend/api/conf/routes
@@ -1,2 +1,3 @@
 # injected controller
 GET     /api/v1/genre               controller.genre.GenreController.getAllGenre
+GET     /api/v1/quiz/:genreId       controller.quiz.QuizController.getQuizListByGenreId(genreId: Long)


### PR DESCRIPTION
## 実施事項
- パスパラーメーターで指定されたgenreIdをキーに`quiz`テーブルと`quiz_choice` テーブルからジャンルのクイズを取得するAPIを実装

http://localhost:9000/api/v1/quiz/1
```
[
    {
        "id": 1,
        "genreId": 1,
        "question": "ビルド時にレンダリングをおこない、WebサーバーにHTMLファイルをキャッシュするレンダリングの種類はどれでしょうか？",
        "options": [
            {
                "id": 1,
                "option": "CSR"
            },
            {
                "id": 2,
                "option": "SSR"
            },
            {
                "id": 3,
                "option": "SG"
            },
            {
                "id": 4,
                "option": "ISR"
            }
        ]
    },
    {
        "id": 2,
        "genreId": 1,
        "question": "グローバルstateに保存した値がページをリロードした際に消えてしまうのはどれでしょうか？",
        "options": [
            {
                "id": 5,
                "option": "インメモリ"
            },
            {
                "id": 6,
                "option": "ローカルストレージ"
            },
            {
                "id": 7,
                "option": "セッションストレージ"
            },
            {
                "id": 8,
                "option": "Cookie"
            }
        ]
    }
]
```

## その他
