### PR TITLE
[Backend] 共通のエラーハンドリング実装

### DIFF
--- a/002-develop/web-developer-training-backend/api/app/config/ErrorHandler.scala
+++ b/002-develop/web-developer-training-backend/api/app/config/ErrorHandler.scala
@@ -1,15 +1,85 @@
 package config
 
+import domain.error.ErrorResponse
+import domain.error.exception.{
+  CreateGenreException,
+  CreateQuizException,
+  NotFoundResourceException,
+  RequestValidationException
+}
 import play.api.http.HttpErrorHandler
-import play.api.mvc.Results.Status
+import play.api.libs.json.Json
+import play.api.mvc.Results._
 import play.api.mvc.{ RequestHeader, Result }
 
+import javax.inject.Singleton
 import scala.concurrent.Future
 
+@Singleton
 class ErrorHandler extends HttpErrorHandler {
-  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = ???
 
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    val errorResponse = ErrorResponse(
+      statusCode,
+      "ClientError",
+      message,
+      request.path
+    )
+    Future.successful(Status(statusCode)(Json.toJson(errorResponse)))
+  }
+
+  /**
+    * アプリケーション内での明示的な例外をハンドリングする
+    * @param request
+    * @param exception
+    * @return
+    */
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
-    Future.successful(Status(500)("A server error occurred: " + exception.getMessage))
+    exception match {
+      case e: RequestValidationException =>
+        val errorResponse = ErrorResponse(
+          400,
+          "RequestValidationException",
+          e.getMessage,
+          request.path
+        )
+        Future.successful(BadRequest(Json.toJson(errorResponse)))
+
+      case e: NotFoundResourceException =>
+        val errorResponse = ErrorResponse(
+          404,
+          "NotFoundResourceException",
+          e.getMessage,
+          request.path
+        )
+        Future.successful(NotFound(Json.toJson(errorResponse)))
+
+      case e: CreateQuizException =>
+        val errorResponse = ErrorResponse(
+          400,
+          "CreateQuizException",
+          e.getMessage,
+          request.path
+        )
+        Future.successful(BadRequest(Json.toJson(errorResponse)))
+
+      case e: CreateGenreException =>
+        val errorResponse = ErrorResponse(
+          400,
+          "CreateGenreException",
+          e.getMessage,
+          request.path
+        )
+        Future.successful(BadRequest(Json.toJson(errorResponse)))
+
+      case e: Exception =>
+        val errorResponse = ErrorResponse(
+          500,
+          "InternalServerError",
+          e.getMessage,
+          request.path
+        )
+        Future.successful(InternalServerError(Json.toJson(errorResponse)))
+    }
   }
 }

--- a/002-develop/web-developer-training-backend/api/app/controller/common/DefaultController.scala
+++ b/002-develop/web-developer-training-backend/api/app/controller/common/DefaultController.scala
@@ -1,0 +1,23 @@
+package controller.common
+
+import domain.error.exception.RequestValidationException
+import play.api.libs.json.{JsValue, Reads}
+import play.api.mvc.{AbstractController, ControllerComponents}
+
+abstract class DefaultController(cc: ControllerComponents) extends AbstractController(cc) {
+  protected def validateRequest[A](request: JsValue)(implicit rds: Reads[A]): A = {
+    request.validate[A].fold(
+      errors => {
+        val errorMessage = errors
+          .flatMap {
+            case (path, validationErrors) =>
+              validationErrors.map(e => s"${path.toJsonString}: ${e.message}")
+          }
+          .mkString(", ")
+
+        throw RequestValidationException(errorMessage)
+      },
+      validRequest => validRequest
+    )
+  }
+}

--- a/002-develop/web-developer-training-backend/api/app/domain/error/ErrorResponse.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/error/ErrorResponse.scala
@@ -1,0 +1,14 @@
+package domain.error
+
+import play.api.libs.json.{ Json, Writes }
+
+case class ErrorResponse(
+    statusCode: Int,
+    errorReason: String,
+    message: String,
+    path: String
+)
+
+object ErrorResponse {
+  implicit val writes: Writes[ErrorResponse] = Json.writes[ErrorResponse]
+}

--- a/002-develop/web-developer-training-backend/api/app/domain/error/exception/CreateGenreException.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/error/exception/CreateGenreException.scala
@@ -1,0 +1,3 @@
+package domain.error.exception
+
+case class CreateGenreException(message: String = "") extends Exception(message)

--- a/002-develop/web-developer-training-backend/api/app/domain/error/exception/CreateQuizException.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/error/exception/CreateQuizException.scala
@@ -1,0 +1,3 @@
+package domain.error.exception
+
+case class CreateQuizException(message: String = "") extends Exception(message)

--- a/002-develop/web-developer-training-backend/api/app/domain/error/exception/NotFoundResourceException.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/error/exception/NotFoundResourceException.scala
@@ -1,0 +1,3 @@
+package domain.error.exception
+
+case class NotFoundResourceException(message: String = "") extends Exception(message)

--- a/002-develop/web-developer-training-backend/api/app/domain/error/exception/RequestValidationException.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/error/exception/RequestValidationException.scala
@@ -1,0 +1,3 @@
+package domain.error.exception
+
+case class RequestValidationException(message: String = "") extends Exception(message)

--- a/002-develop/web-developer-training-backend/api/app/domain/genre/CreateGenreException.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/genre/CreateGenreException.scala
@@ -1,3 +1,0 @@
-package domain.genre
-
-class CreateGenreException(val message: String) extends RuntimeException(message)

--- a/002-develop/web-developer-training-backend/api/app/domain/genre/Genre.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/genre/Genre.scala
@@ -1,13 +1,14 @@
 package domain.genre
 
+import domain.error.exception.CreateGenreException
 import infrastructure.genre.GenreEntity
 
 case class Genre private (id: Long, genreCode: String, genreName: String) {
   if (id < 0) {
-    throw new CreateGenreException("Genre idは自然数である必要があります")
+    throw CreateGenreException("Genre idは自然数である必要があります")
   }
   if (genreName.length > 30) {
-    throw new CreateGenreException("Genre nameは30文字以内である必要があります")
+    throw CreateGenreException("Genre nameは30文字以内である必要があります")
   }
 }
 

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/CreateQuizException.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/CreateQuizException.scala
@@ -1,3 +1,0 @@
-package domain.quiz
-
-class CreateQuizException(val message: String) extends RuntimeException(message)

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/Quiz.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/Quiz.scala
@@ -1,16 +1,17 @@
 package domain.quiz
 
+import domain.error.exception.CreateQuizException
 import infrastructure.quiz.{ QuizChoiceEntity, QuizEntity }
 
 case class Quiz private (id: Long, genreId: Long, question: String, options: List[QuizChoice]) {
   if (id < 0) {
-    throw new CreateQuizException("Quiz idは自然数である必要があります")
+    throw CreateQuizException("Quiz idは自然数である必要があります")
   }
   if (genreId < 0) {
-    throw new CreateQuizException("Genre idは自然数である必要があります")
+    throw CreateQuizException("Genre idは自然数である必要があります")
   }
   if (question.length > 1000) {
-    throw new CreateQuizException("Questionは1000文字以内である必要があります")
+    throw CreateQuizException("Questionは1000文字以内である必要があります")
   }
 }
 

--- a/002-develop/web-developer-training-backend/api/app/domain/quiz/QuizChoice.scala
+++ b/002-develop/web-developer-training-backend/api/app/domain/quiz/QuizChoice.scala
@@ -1,5 +1,6 @@
 package domain.quiz
 
+import domain.error.exception.CreateQuizException
 import infrastructure.quiz.QuizChoiceEntity
 
 case class QuizChoice private (
@@ -11,7 +12,7 @@ case class QuizChoice private (
     explanation: String
 ) {
   if (content.length > 1000) {
-    throw new CreateQuizException("Contentは1000文字以内である必要があります")
+    throw CreateQuizException("Contentは1000文字以内である必要があります")
   }
 }
 

--- a/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizRepositoryImpl.scala
+++ b/002-develop/web-developer-training-backend/api/app/infrastructure/quiz/QuizRepositoryImpl.scala
@@ -1,5 +1,6 @@
 package infrastructure.quiz
 
+import domain.error.exception.NotFoundResourceException
 import domain.quiz.{ Quiz, QuizAnswer, QuizExplanation, QuizRepository }
 import scalikejdbc._
 
@@ -54,7 +55,8 @@ class QuizRepositoryImpl extends QuizRepository {
 
     quizChoiceEntityOpt match {
       case Some(quizChoiceEntity) => QuizAnswer.build(quizChoiceEntity.isAnswer, quizChoiceEntity.explanation)
-      case None                   => throw new IllegalArgumentException("Quiz choice not found.")
+      case None =>
+        throw NotFoundResourceException(s"Quiz choice not found. >>> quizId: $quizId, quizChoiceId: $quizChoiceId")
     }
   }
 
@@ -74,7 +76,7 @@ class QuizRepositoryImpl extends QuizRepository {
 
     quizChoiceEntityOpt match {
       case Some(quizChoiceEntity) => QuizExplanation.build(quizChoiceEntity.id, quizChoiceEntity.explanation)
-      case None                   => throw new IllegalArgumentException("Quiz choice not found.")
+      case None                   => throw NotFoundResourceException(s"Quiz choice not found. >>> quizId: $quizId")
     }
   }
 }


### PR DESCRIPTION
## 実施事項
タイトルの本格実装

ex. 

http://localhost:9000/api/v1/quiz/answer
POST

```
{
    "quizId": "a",
    "quizChoiceId": "b"
}
```

res
```
{
    "statusCode": 400,
    "errorReason": "RequestValidationException",
    "message": "obj.quizId: error.expected.jsnumber, obj.quizChoiceId: error.expected.jsnumber",
    "path": "/api/v1/quiz/answer"
}
```

http://localhost:9000/api/v1/quiz/100/explanation
GET

res
```
{
    "statusCode": 404,
    "errorReason": "NotFoundResourceException",
    "message": "Quiz choice not found. >>> quizId: 100",
    "path": "/api/v1/quiz/100/explanation"
}
```

## その他
